### PR TITLE
Support parameterized cofactors

### DIFF
--- a/Single_protein/1.MD_with_gromacs/environment.yml
+++ b/Single_protein/1.MD_with_gromacs/environment.yml
@@ -13,5 +13,6 @@ dependencies:
   - biobb_gromacs>=4.2.0
   - biobb_amber>=4.2.0
   - biobb_analysis>=4.2.0
+  - biobb_chemistry>=4.2.0
   - biobb_pdb_tools>=4.2.0         # Line 81 of pdb_tofasta -> fu.log(' '.join(self.cmd), self.out_log, self.global_log)
 prefix: /shared/work/BiobbWorkflows/envs/biobb_md

--- a/Single_protein/1.MD_with_gromacs/input_HPC.yml
+++ b/Single_protein/1.MD_with_gromacs/input_HPC.yml
@@ -10,8 +10,12 @@ can_write_console_log: False                                                    
 restart: True                                                                                   # Skip steps already performed
 remove_tmp: True                                                                                # Remove temporal files
 
-# Step 1: extract molecules from input PDB file
-step1_extractMolecule:
+############################################################
+# Section 1 (Steps A-B): extract atoms from input PDB file #
+############################################################
+
+# Step 1A: extract atoms from input PDB file
+step1A_extractAtoms:
   tool: extract_molecule
   paths:
     input_structure_path: /path/to/input                            # Overwritten by command line
@@ -20,11 +24,22 @@ step1_extractMolecule:
     molecule_type: chains                                           # type of molecule to extract. Options: all, protein, na, dna, rna, chains
     chains: [A]                                                     # if "chains" is selected in molecule_type. Options: None, [A], [A, B], ...
 
+# Step 1B: extract heteroatoms from input PDB file
+step1B_extractHeteroatoms:
+  tool: extract_heteroatoms
+  paths:
+    input_structure_path: dependency/step1A_extractAtoms/input_structure_path  # Overwritten by command line
+    output_heteroatom_path: ligands.pdb
+
+########################################################
+# Section 2 (Steps A-I): prepare main structure for MD #
+########################################################
+
 # Step 2 A: fix alternative locations of residues if any with biobb_structure_checking and the Modeller suite (if key property is given)
 step2A_fixaltlocs:                 
   tool: fix_altlocs
   paths:
-    input_pdb_path: dependency/step1_extractMolecule/output_molecule_path
+    input_pdb_path: dependency/step1A_extractAtoms/output_molecule_path
     output_pdb_path: fixaltlocs.pdb
   properties:
     altlocs: null                                                        # Format: ["Chain Residue_number:Altloc"], e.g. # ["A339:A", "A171:B", "A768:A"] 
@@ -54,13 +69,12 @@ step2C_canonical_fasta:
 step2C_pdb_tofasta:
   tool: biobb_pdb_tofasta
   paths:
-    input_file_path: dependency/step1_extractMolecule/input_structure_path
+    input_file_path: dependency/step1A_extractAtoms/input_structure_path
     output_file_path: pdbFasta.fasta
   properties:
     multi: True
 
 # Step 2 D: Model missing backbone atoms with biobb_structure_checking and the Modeller suite
-# Optional step (activate from command line with --fix_backbn)
 # It requires a MODELLER license 
 step2D_fixbackbone:
   tool: fix_backbone
@@ -100,7 +114,7 @@ step2G_fixamides:
     input_pdb_path: dependency/step2F_fixssbonds/output_pdb_path
     output_pdb_path: fixamides.pdb
   properties:
-    modeller_key: HERE YOUR MODELLER KEY # MODELLER license key
+    # modeller_key: HERE YOUR MODELLER KEY # MODELLER license key
 
 step2H_fixchirality:
   tool: fix_chirality
@@ -118,111 +132,187 @@ step2I_renumberstructure:
     renumber_residues: True
     renumber_residues_per_chain: False
 
-# Section 3 (Steps 3-10): prepare system and minimize energy
-step3_pdb2gmx:
+##################################################################
+# Section 3 (Steps A-I): Prepare topology and coordinates for MD #
+##################################################################
+
+# Step 3 A: Generate the topology of the structure with pdb2gmx
+step3A_structure_topology:
   tool: pdb2gmx
   paths:
     input_pdb_path: dependency/step2I_renumberstructure/output_structure_path
-    output_gro_path: pdb2gmx.gro
-    output_top_zip_path: pdb2gmx_top.zip
+    output_gro_path: structure.gro
+    output_top_zip_path: structure_top.zip
   properties:
     force_field: amber99sb-ildn   # gromos45a3, charmm27, gromos53a6, amber96, amber99, gromos43a2, gromos54a7, gromos43a1, amberGS, gromos53a5, amber99sb, amber03, amber99sb-ildn, oplsaa, amber94, amber99sb-star-ildn-mut
     water_type: tip3p             # spc, spce, tip3p, tip4p, tip5p, tips3p
     ignh: False                   # Ignore hydrogens in the input structure
     merge: False                  # Merge all chains into one molecule
-    # his:                        # HIS protonation state array
+    # his: '1 1'                  # HIS protonation state array
 
-step4_editconf:
+step3B_cofactors_topology:
+  tool: leap_gen_top
+  paths:
+    input_pdb_path: dependency/step1B_extractHeteroatoms/output_heteroatom_path
+    input_frcmod_path: path/to/frcmod.zip
+    input_prep_path: path/to/prep.zip
+    output_pdb_path: cofactors.pdb
+    output_top_path: cofactors.prmtop
+    output_crd_path: cofactors.inpcrd
+  properties:
+    forcefield: ["protein.ff14SB"]
+    binary_path: /eb/x86_64/software/Amber/20.13-foss-2022a-AmberTools-22.5-CUDA-11.7.0/bin/tleap
+
+step3C_amber_to_gmx:
+  tool: acpype_convert_amber_to_gmx
+  paths:
+    input_crd_path: dependency/step3B_cofactors_topology/output_crd_path
+    input_top_path: dependency/step3B_cofactors_topology/output_top_path
+    output_path_gro: cofactors.gro
+    output_path_top: cofactors.top # Error if we try to name it .itp
+  properties:
+    basename: cofactors
+
+step3D_structure_pdb:
+  tool: gmx_trjconv_str
+  paths: 
+    input_top_path: dependency/step3A_structure_topology/output_gro_path
+    input_structure_path: dependency/step3A_structure_topology/output_gro_path
+    output_str_path: structure.pdb
+
+step3E_cofactors_pdb:
+  tool: gmx_trjconv_str
+  paths: 
+    input_top_path: dependency/step3C_amber_to_gmx/output_path_gro
+    input_structure_path: dependency/step3C_amber_to_gmx/output_path_gro
+    output_str_path: cofactors.pdb   
+
+step3F_complex_pdb:
+  tool: cat_pdb
+  paths:
+    input_structure1: dependency/step3D_structure_pdb/output_str_path
+    input_structure2: dependency/step3E_cofactors_pdb/output_str_path
+    output_structure_path: complex.pdb
+
+step3G_make_cofactors_ndx:
+  tool: make_ndx
+  paths:
+    input_structure_path: dependency/step3C_amber_to_gmx/output_path_gro
+    output_ndx_path: cofactors_heavy_atoms.ndx
+  properties:
+    selection: "0 & ! a H*"
+
+step3H_cofactor_restraints:
+  tool: genrestr
+  paths:
+    input_structure_path: dependency/step3C_amber_to_gmx/output_path_gro
+    input_index_path: dependency/step3G_make_cofactors_ndx/output_ndx_path
+    output_itp_path: cofactors_restraints.itp
+
+step3I_append_ligand:
+  tool: append_ligand
+  paths:
+    input_top_zip_path: dependency/step3A_structure_topology/output_top_zip_path  # Path to structure topology zip file
+    input_itp_path: dependency/step3C_amber_to_gmx/output_path_top                # Path to ligand topology file - itp
+    input_posres_itp_path: dependency/step3H_cofactor_restraints/output_itp_path  # Path to ligand position restraint topology file
+    output_top_zip_path: complex_top.zip
+
+step3J_editconf:
   tool: editconf
   paths:
-    input_gro_path: dependency/step3_pdb2gmx/output_gro_path
+    input_gro_path: dependency/step3A_structure_topology/output_gro_path
     output_gro_path: editconf.gro
   properties:
     box_type: octahedron         # cubic, triclinic, octahedron, dodecahedron
     distance_to_molecule: 1.0    # Distance of the box from the outermost atom in nm
 
-step5_solvate:
+step3K_solvate:
   tool: solvate
   paths:
-    input_solute_gro_path: dependency/step4_editconf/output_gro_path
-    output_gro_path: solvate.gro
-    input_top_zip_path: dependency/step3_pdb2gmx/output_top_zip_path
+    input_solute_gro_path: dependency/step3J_editconf/output_gro_path
+    input_top_zip_path: dependency/step3A_structure_topology/output_top_zip_path
     output_top_zip_path: solvate_top.zip
-
-step6_grompp_genion:
+    output_gro_path: solvate.gro
+    
+step3L_grompp_genion:
   tool: grompp
   paths:
-    input_gro_path: dependency/step5_solvate/output_gro_path
-    input_top_zip_path: dependency/step5_solvate/output_top_zip_path
+    input_gro_path: dependency/step3K_solvate/output_gro_path
+    input_top_zip_path: dependency/step3K_solvate/output_top_zip_path
     output_tpr_path: gppion.tpr
   properties:
     simulation_type: minimization
-    maxwarn: 2
+    maxwarn: 10                      # NOTE: this will be cofactor dependent!! :o - the warning is for each atom with redefined parameters
 
-step7_genion:
+step3M_genion:
   tool: genion
   paths:
-    input_tpr_path: dependency/step6_grompp_genion/output_tpr_path
-    output_gro_path: genion.gro
-    input_top_zip_path: dependency/step5_solvate/output_top_zip_path
+    input_tpr_path: dependency/step3L_grompp_genion/output_tpr_path
+    input_top_zip_path: dependency/step3K_solvate/output_top_zip_path
     output_top_zip_path: genion_top.zip
+    output_gro_path: genion.gro
   properties:
     neutral: True             # Neutralize charge of the system
     concentration: 0.15       # Concentration of ions in mols/L
 
-step7B_gro2pdb:
+step3N_gro2pdb:
   tool: gmx_trjconv_str
   paths: 
-    input_top_path: dependency/step7_genion/output_gro_path
-    input_structure_path: dependency/step7_genion/output_gro_path
+    input_top_path: dependency/step3M_genion/output_gro_path
+    input_structure_path: dependency/step3M_genion/output_gro_path
     output_str_path: topology.pdb
 
-step8_grompp_min:
+
+#############################################################################
+# Section 4 (Steps A-I): Minimize and equilibrate the initial configuration #
+#############################################################################
+
+step4A_grompp_min:
   tool: grompp
   paths:
-    input_gro_path: dependency/step7_genion/output_gro_path
-    input_top_zip_path: dependency/step7_genion/output_top_zip_path
+    input_gro_path: dependency/step3M_genion/output_gro_path
+    input_top_zip_path: dependency/step3M_genion/output_top_zip_path
     output_tpr_path: gppmin.tpr
   properties:
     simulation_type: minimization
     mdp:
-      nsteps: 100000
-      emtol: 10
+      integrator: steep
+      nsteps: 50000
+      emtol: 1000
+      emstep: 0.01
     
-step9_mdrun_min:
+step4B_mdrun_min:
   tool: mdrun
   paths:
-    input_tpr_path: dependency/step8_grompp_min/output_tpr_path
+    input_tpr_path: dependency/step4A_grompp_min/output_tpr_path
     output_trr_path: min.trr
     output_gro_path: min.gro
     output_edr_path: min.edr
     output_log_path: min.log
-
-# NOTE: To end up creating just the "System" group I think we can skip this step
-step9B_make_ndx:
+    
+step4C_make_ndx:
   tool: make_ndx 
   paths:
-    input_structure_path: dependency/step9_mdrun_min/output_gro_path
+    input_structure_path: dependency/step4B_mdrun_min/output_gro_path
     output_ndx_path: index.ndx
   properties:
-    selection: "System"
+    selection: '"System"'
 
-step10_energy_min:
+step4D_energy_min:
   tool: gmx_energy
   paths:
-    input_energy_path: dependency/step9_mdrun_min/output_edr_path
+    input_energy_path: dependency/step4B_mdrun_min/output_edr_path
     output_xvg_path: min_ene.xvg
   properties:
     terms: ["Potential"]
-    xvg: xmgr # xmgrace, xmgr, none
+    xvg: xmgr 
 
-# Section 4 (Steps 11-13): NVT equilibration
-step11_grompp_nvt:
+step4E_grompp_nvt:
   tool: grompp
   paths:
-    input_gro_path: dependency/step9_mdrun_min/output_gro_path
-    input_ndx_path: dependency/step9B_make_ndx/output_ndx_path
-    input_top_zip_path: dependency/step7_genion/output_top_zip_path
+    input_gro_path: dependency/step4B_mdrun_min/output_gro_path
+    input_ndx_path: dependency/step4C_make_ndx/output_ndx_path
+    input_top_zip_path: dependency/step3M_genion/output_top_zip_path
     output_tpr_path: gppnvt.tpr
   properties:
     simulation_type: nvt
@@ -232,34 +322,32 @@ step11_grompp_nvt:
       nsteps: 10000
       dt: 0.002
 
-step12_mdrun_nvt:
+step4F_mdrun_nvt:
   tool: mdrun
   paths:
-    input_tpr_path: dependency/step11_grompp_nvt/output_tpr_path
+    input_tpr_path: dependency/step4E_grompp_nvt/output_tpr_path
     output_trr_path: nvt.trr
     output_gro_path: nvt.gro
     output_edr_path: nvt.edr
     output_log_path: nvt.log
     output_cpt_path: nvt.cpt
 
-step13_temp_nvt:
+step4G_temp_nvt:
   tool: gmx_energy
   paths:
-    input_energy_path: dependency/step12_mdrun_nvt/output_edr_path
+    input_energy_path: dependency/step4F_mdrun_nvt/output_edr_path
     output_xvg_path: nvt_temp.xvg
   properties:
     terms: ["Temperature"]
-    xvg: xmgr # xmgrace, xmgr, none
+    xvg: xmgr 
 
-# Section 5 (Steps 14-16): NPT equilibration
-
-step14_grompp_npt:
+step4H_grompp_npt:
   tool: grompp
   paths:
-    input_gro_path: dependency/step12_mdrun_nvt/output_gro_path
-    input_ndx_path: dependency/step9B_make_ndx/output_ndx_path
-    input_top_zip_path: dependency/step7_genion/output_top_zip_path
-    input_cpt_path: dependency/step12_mdrun_nvt/output_cpt_path
+    input_gro_path: dependency/step4F_mdrun_nvt/output_gro_path
+    input_ndx_path: dependency/step4C_make_ndx/output_ndx_path
+    input_top_zip_path: dependency/step3M_genion/output_top_zip_path
+    input_cpt_path: dependency/step4F_mdrun_nvt/output_cpt_path
     output_tpr_path: gppnpt.tpr
   properties:
     simulation_type: npt
@@ -269,46 +357,48 @@ step14_grompp_npt:
       ref-t: 300 300
       tc-grps: "Protein Water_and_ions"
 
-step15_mdrun_npt:
+step4I_mdrun_npt:
   tool: mdrun
   paths:
-    input_tpr_path: dependency/step14_grompp_npt/output_tpr_path
+    input_tpr_path: dependency/step4H_grompp_npt/output_tpr_path
     output_trr_path: npt.trr
     output_gro_path: npt.gro
     output_edr_path: npt.edr
     output_log_path: npt.log
     output_cpt_path: npt.cpt
 
-step16_density_npt:
+step4J_density_npt:
   tool: gmx_energy
   paths:
-    input_energy_path: dependency/step15_mdrun_npt/output_edr_path
+    input_energy_path: dependency/step4I_mdrun_npt/output_edr_path
     output_xvg_path: npt_press_den.xvg
   properties:
     terms: ["Pressure", "Density"]
-    xvg: xmgr # xmgrace, xmgr, none
+    xvg: xmgr 
 
-# Section 6 (Steps 17-24): production trajectories
+############################################
+# Section 5 (Steps A-I): MD production run #
+############################################
 
 step17_grompp_md:
   tool: grompp
   paths:
-    input_gro_path: dependency/step15_mdrun_npt/output_gro_path
-    input_cpt_path: dependency/step15_mdrun_npt/output_cpt_path 
-    input_ndx_path: dependency/step9B_make_ndx/output_ndx_path
-    input_top_zip_path: dependency/step7_genion/output_top_zip_path
+    input_gro_path: dependency/step4I_mdrun_npt/output_gro_path
+    input_cpt_path: dependency/step4I_mdrun_npt/output_cpt_path 
+    input_ndx_path: dependency/step4C_make_ndx/output_ndx_path
+    input_top_zip_path: dependency/step3M_genion/output_top_zip_path
     output_tpr_path: gppmd.tpr
   properties:
     simulation_type: free
     mdp:
-      nsteps: 250000
+      nsteps: 10000
       dt: 0.002 
       ref-t: 300 300
       tc-grps: "Protein Water_and_ions"
-      nstxout: 2500      # freq. of .xtc trajectory (coordinates) writing in time steps 
-      nstvout: 2500      # freq. of .trr trajectory (velocities) writing in time steps
-      nstfout: 2500
-      nstenergy: 2500
+      nstxout: 500      # freq. of trajectory (coordinates) writing in time steps 
+      nstvout: 500      # freq. of trajectory (velocities) writing in time steps
+      nstfout: 500
+      nstenergy: 500
       continuation: 'yes'
       gen-vel: 'no'          
       gen-temp: 300   
@@ -327,37 +417,37 @@ step18_mdrun_md:
 step19_rmsd_equilibrated:
   tool: gmx_rms
   paths:
-    input_structure_path: dependency/step15_mdrun_npt/output_gro_path
+    input_structure_path: dependency/step4I_mdrun_npt/output_gro_path
     input_traj_path: dependency/step18_mdrun_md/output_trr_path
     output_xvg_path: md_rmsdfirst.xvg
   properties:
     selection: Backbone
-    xvg: xmgr # xmgrace, xmgr, none
+    xvg: xmgr 
 
 step20_rmsd_experimental:
   tool: gmx_rms
   paths:
-    input_structure_path: dependency/step8_grompp_min/input_gro_path
+    input_structure_path: dependency/step4A_grompp_min/input_gro_path
     input_traj_path: dependency/step18_mdrun_md/output_trr_path
     output_xvg_path: md_rmsdexp.xvg
   properties:
     selection: Backbone
-    xvg: xmgr # xmgrace, xmgr, none
+    xvg: xmgr 
   
 step21_rgyr:
   tool: gmx_rgyr
   paths:
-    input_structure_path: dependency/step15_mdrun_npt/output_gro_path
+    input_structure_path: dependency/step4I_mdrun_npt/output_gro_path
     input_traj_path: dependency/step18_mdrun_md/output_trr_path
     output_xvg_path: md_rgyr.xvg
   properties:
     selection: Backbone
-    xvg: xmgr # xmgrace, xmgr, none
+    xvg: xmgr 
 
 step22_rmsf:
   tool: cpptraj_rmsf
   paths:
-    input_top_path: dependency/step7B_gro2pdb/output_str_path
+    input_top_path: dependency/step3N_gro2pdb/output_str_path
     input_traj_path: dependency/step18_mdrun_md/output_trr_path
     output_cpptraj_path: md_rmsf.xmgr   # .dat, .agr, .xmgr, .gnu
   properties:
@@ -371,6 +461,8 @@ step23_trjcat:
   paths:
     input_trj_zip_path: all_trajectories_trr.zip
     output_trj_path: all_trajectories.xtc
+  properties:
+    concatenate: True
 
 # NOTE: Dry, image and fit the trajectory (parts) or the trajectories (replicas) - if parts we need to do this here, after the concatenation
 
@@ -378,18 +470,21 @@ step24_dry_trj:
   tool: gmx_trjconv_trj
   paths: 
     input_traj_path: dependency/step23_trjcat/output_trj_path
-    input_top_path: dependency/step15_mdrun_npt/output_gro_path
-    input_index_path: dependency/step9B_make_ndx/output_ndx_path
+    input_top_path: dependency/step4I_mdrun_npt/output_gro_path
+    input_index_path: dependency/step4C_make_ndx/output_ndx_path
     output_traj_path: dry_traj.xtc
   properties:
     selection: Protein
+    start: 0
+    end: -1
+    dt: 1
 
 step25_dry_str:
   tool: gmx_trjconv_str
   paths: 
-    input_structure_path: dependency/step15_mdrun_npt/output_gro_path
-    input_top_path: dependency/step15_mdrun_npt/output_gro_path
-    input_index_path: dependency/step9B_make_ndx/output_ndx_path
+    input_structure_path: dependency/step4I_mdrun_npt/output_gro_path
+    input_top_path: dependency/step4I_mdrun_npt/output_gro_path
+    input_index_path: dependency/step4C_make_ndx/output_ndx_path
     output_str_path: dry_structure.gro
   properties:
     selection: Protein
@@ -402,7 +497,7 @@ step26_image_traj:
   paths:
     input_traj_path: dependency/step24_dry_trj/output_traj_path
     input_top_path: dependency/step25_dry_str/output_str_path
-    input_index_path: dependency/step9B_make_ndx/output_ndx_path
+    input_index_path: dependency/step4C_make_ndx/output_ndx_path
     output_traj_path: imaged_traj.xtc
   properties:
     center_selection: Protein
@@ -416,7 +511,7 @@ step27_fit_traj:
   paths:
     input_traj_path: dependency/step26_image_traj/output_traj_path
     input_top_path: dependency/step25_dry_str/output_str_path
-    input_index_path: dependency/step9B_make_ndx/output_ndx_path
+    input_index_path: dependency/step4C_make_ndx/output_ndx_path
     output_traj_path: fitted_traj.xtc
   properties:
     fit_selection: Protein

--- a/Single_protein/1.MD_with_gromacs/run_HPC_HIS.sl
+++ b/Single_protein/1.MD_with_gromacs/run_HPC_HIS.sl
@@ -20,15 +20,23 @@ source activate /shared/work/BiobbWorkflows/envs/biobb_md
 
 # Path to the workflow
 REPO_PATH=/shared/work/BiobbWorkflows/src/biobb_workflows
-WF_PATH=$REPO_PATH/euCanSHare/Single_protein_wfs/1.MD_with_mutation
+WF_PATH=$REPO_PATH/Single_protein/1.MD_with_gromacs/
 
 # Input arguments
 INPUT_PDB=$1
 PDB_CHAIN=$2
 OUTPUT_DIR=$3
-NUM_PARTS=$4
-NSTEPS=$5
-ANALYSIS=$6
+LIGAND_PARAMETERS=$4
+NUM_PARTS=$5
+NSTEPS=$6
+DO_FINAL_ANALYSIS=$7
+
+# Read the condition to do the final analysis
+if [ "$DO_FINAL_ANALYSIS" == "true" ]; then
+    FINAL_ANALYSIS="--final_analysis"
+else
+    FINAL_ANALYSIS=""
+fi
 
 # Create folder for the HIS protonation
 mkdir -p $OUTPUT_DIR/his_protonation
@@ -57,7 +65,7 @@ if [ ${#histidine_residues[@]} -eq 0 ]; then
 
     echo "No histidine residues found. Launching the workflow."
 
-    python $WF_PATH/biobb_md_setup_mutation.py --config input_HPC.yml --num_parts $NUM_PARTS --input_pdb $INPUT_PDB --output $OUTPUT_DIR --pdb_chains $PDB_CHAIN --nsteps $NSTEPS --analysis $ANALYSIS
+    python $WF_PATH/biobb_md_setup_mutation.py --config input_HPC.yml --num_parts $NUM_PARTS --input_pdb $INPUT_PDB --output $OUTPUT_DIR --pdb_chains $PDB_CHAIN --nsteps $NSTEPS $FINAL_ANALYSIS --ligand_parameters $LIGAND_PARAMETERS
 
 elif [ ${#histidine_residues[@]} -ne 0 ]; then
 
@@ -84,5 +92,5 @@ elif [ ${#histidine_residues[@]} -ne 0 ]; then
         esac
     done
 
-    python $WF_PATH/biobb_md_setup_mutation.py --config input_HPC.yml --num_parts $NUM_PARTS --input_pdb $INPUT_PDB --output $OUTPUT_DIR --pdb_chains $PDB_CHAIN --nsteps $NSTEPS --analysis $ANALYSIS --his "$histidine_numbers"
+    python $WF_PATH/biobb_md_setup_mutation.py --config input_HPC.yml --num_parts $NUM_PARTS --input_pdb $INPUT_PDB --output $OUTPUT_DIR --pdb_chains $PDB_CHAIN --nsteps $NSTEPS $FINAL_ANALYSIS --his "$histidine_numbers" --ligand_parameters $LIGAND_PARAMETERS
 fi


### PR DESCRIPTION
- Added support to include cofactors from the PDB in the simulation, as long as they contain amber parameters .frcmod and .prep in the ligand parameters folder provided by the user
- The cofactors are detected from the PDB automatically using Biopython
- Divided steps into a hierarchical structure with numbers and letters
- Added/modified new biobbs: acpype_convert_amber_to_gmx (new), leap_gen_top (modified)
- Added processing of gromacs cofactor topology coming from acpype to include it as a .itp in the main .top